### PR TITLE
(SIMP-5362) Fixed error in tftpboot ERB

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Mon Sep 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
+- Fixed error in tftpboot erb in simpsetup.
+
 Wed Aug 30 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - UNRELEASED
 
 - Cleaned up scripts and manifests:

--- a/puppet/modules/simpsetup/templates/site/manifests/tftpboot.pp.erb
+++ b/puppet/modules/simpsetup/templates/site/manifests/tftpboot.pp.erb
@@ -5,7 +5,7 @@
 #   By default, this uses HTTP and the host's *primary* IP address.
 #
 class site::tftpboot (
-  Simplib::URI $kickstart_server_uri = "http://${facts['ipaddress']}/ks"
+  Simplib::URI $kickstart_server_uri = "https://${facts['ipaddress']}/ks"
 ){
   include '::tftpboot'
 
@@ -14,7 +14,7 @@ class site::tftpboot (
       tftpboot::linux_model { 'el7_x86_64':
         kernel => 'centos-7-x86_64/vmlinuz',
         initrd => 'centos-7-x86_64/initrd.img',
-        ks     => "https://${kickstart_server_uri}/pupclient_x86_64.cfg",
+        ks     => "${kickstart_server_uri}/pupclient_x86_64.cfg",
         extra  => "inst.noverifyssl ksdevice=bootif\nipappend 2"
       }
     }
@@ -22,7 +22,7 @@ class site::tftpboot (
       tftpboot::linux_model { 'el6_x86_64':
         kernel => 'centos-6-x86_64/vmlinuz',
         initrd => 'centos-6-x86_64/initrd.img',
-        ks     => "https://${kickstart_server_uri}/pupclient_x86_64.cfg",
+        ks     => "${kickstart_server_uri}/pupclient_x86_64.cfg",
         extra  => "noverifyssl ksdevice=bootif\nipappend 2"
       }
     }


### PR DESCRIPTION
  - the tftpboot.erb in site manifest (configured by simpsetup) was
    creating the template wrong in the tftpboot directory.

SIMP-5362 #close