### PR TITLE
(SIMP-6344) Update packer to work with 6.4.0 Alpha

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,14 @@
+Wed May 08 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
+* Update to use simp-cli 6.4 alpha.  This puts things in production environment.
+  Added ipacker user variable simpenviroment so the directory where files are
+  copied to can be changed.  How ever the scripts
+  that run on the server use puppet config to determine environment and we do not
+  yet use the packer user  variable simpenvironment to set the  environment
+  in the puppet.conf file.  It is only used to copy files to the correct directory.
+
 Mon Apr 29 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
 * change simp.json file to use simpenv script in simp-utils
 * removed linked file in site module.  Packer can't handle linked files
-
 
 Thu Apr 18 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
 * Updated to work with new r10k iso install process.  It will no longer work

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,16 @@
 Wed May 08 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
-* Update to use simp-cli 6.4 alpha.  This puts things in production environment.
-  Added ipacker user variable simpenviroment so the directory where files are
+* Update to use simp-cli 6.4 alpha (version 5.0.0).  This puts things in production environment.
+  Added packer user variable simpenviroment so the directory where files are
   copied to can be changed.  How ever the scripts
   that run on the server use puppet config to determine environment and we do not
   yet use the packer user  variable simpenvironment to set the  environment
   in the puppet.conf file.  It is only used to copy files to the correct directory.
+* Must use
+    simp-environment-skeleton >= 7.0.0
+    simp-rsync-skeleton >= 7.0.0
+    simp-adapter >= 1.0.0
+    simp-cli >= 5.0.0
+    simp-utils >= 6.2.0
 
 Mon Apr 29 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
 * change simp.json file to use simpenv script in simp-utils

--- a/lib/simp/packer/config/prepper.rb
+++ b/lib/simp/packer/config/prepper.rb
@@ -33,6 +33,7 @@ module Simp
         def default_settings
           {
             'vm_description'      => 'SIMP-PACKER-BUILD',
+            'simpenvironment'     => 'production',
             'output_directory'    => "#{@testdir}/OUTPUT",
             'nat_interface'       => 'enp0s3',
             'host_only_interface' => 'enp0s8',

--- a/puppet/modules/simpsetup/hiera.yaml
+++ b/puppet/modules/simpsetup/hiera.yaml
@@ -1,0 +1,15 @@
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "OS + Release"
+    path: "os/%{facts.operatingsystem}-%{facts.operatingsystemmajrelease}.yaml"
+  - name: "OS"
+    path: "os/%{facts.operatingsystem}.yaml"
+  - name: "Kernel"
+    path: "os/%{facts.kernel}.yaml"
+  - name: "Common"
+    path: "common.yaml"
+

--- a/puppet/modules/simpsetup/manifests/dhcp.pp
+++ b/puppet/modules/simpsetup/manifests/dhcp.pp
@@ -14,15 +14,17 @@
 # @param $dnsip IP address of dns server
 # @param $domain  Domain name
 # @param $fwdaddr the first three octets of the puppetserver IP.
+# @param $env   the puppet environment
 #
 class simpsetup::dhcp (
   String      $ksip      = $simpsetup::ipaddress,
   String      $dnsip     = $simpsetup::ipaddress,
   String      $domain    = $simpsetup::domain,
   String      $fwdaddr   = $simpsetup::fwdaddr,
+  String      $env       = $simpsetup::environment,
 ){
 
-  $rsync_dir = "/var/simp/environments/simp/rsync/${facts['os']['name']}/Global/dhcpd"
+  $rsync_dir = "/var/simp/environments/${env}/rsync/${facts['os']['name']}/Global/dhcpd"
 
   $iface = $facts['networking']['primary']
   $_macprefix = split($facts['networking']['interfaces'][$iface]['mac'],':')

--- a/puppet/modules/simpsetup/manifests/dns.pp
+++ b/puppet/modules/simpsetup/manifests/dns.pp
@@ -11,14 +11,15 @@ class simpsetup::dns(
   String              $dnsserver = $simpsetup::dnsserver,
   String              $ipaddress = $simpsetup::ipaddress,
   String              $relver = $simpsetup::relver,
-  String              $allowed_nets = $simpsetup::allowed_nets
+  String              $allowed_nets = $simpsetup::allowed_nets,
+  String              $env = $simpsetup::environment
 ){
 
   $_ip = split($ipaddress,'\.')
   $fwdaddr = join($_ip[0,3],'.')
   $lastip  = $_ip[3]
   $revaddr = join(reverse($_ip[0,3]),'.')
-  $dns_rsync_dir = "/var/simp/environments/simp/rsync/CentOS/${relver}/bind_dns/default/named"
+  $dns_rsync_dir = "/var/simp/environments/${env}/rsync/CentOS/${relver}/bind_dns/default/named"
 
   file { "${dns_rsync_dir}/etc/zones/${domain}":
     owner   => 'root',

--- a/puppet/modules/simpsetup/manifests/init.pp
+++ b/puppet/modules/simpsetup/manifests/init.pp
@@ -29,6 +29,7 @@ class simpsetup(
   String           $dnsserver = $facts['networking']['fqdn'],
   String           $ipaddress = $facts['networking']['ip'],
   String           $relver = $facts['os']['release']['major'],
+  String           $environment = pick("${facts['puppet_settings']['main']['environment']}",'production'),
   Array[String]    $servers = ['21','22','23','24','25','26','27','28','29'],
   Array[String]    $clients = ['31','32','33','34','35','36','37','38','39']
 ){

--- a/puppet/modules/simpsetup/manifests/ldap.pp
+++ b/puppet/modules/simpsetup/manifests/ldap.pp
@@ -9,7 +9,8 @@
 # @param    $password The password for the root user in LDAP.
 class simpsetup::ldap(
   String      $domain    = $simpsetup::domain,
-  String      $password  = 'P@ssw0rdP@ssw0rd'
+  String      $password  = 'P@ssw0rdP@ssw0rd',
+  String      $env       = $simpsetup::environment
 ) {
 
   $_domain = split($domain, '\.')
@@ -33,13 +34,13 @@ class simpsetup::ldap(
 
   exec { 'packer_addto_ldap':
     command => "/usr/bin/ldapadd -Z -x -w ${password} -D \"cn=LDAPAdmin,OU=People,${basedn}\" -f /tmp/add.ldif",
-    cwd     => '/var/simp/environments/simp/FakeCA',
+    cwd     => "/var/simp/environments/${env}/FakeCA",
     require => File['/tmp/add.ldif']
   }
 
   exec { 'packer_mod_ldap':
     command => "/usr/bin/ldapmodify -Z -x -w ${password} -D \"cn=LDAPAdmin,OU=People,${basedn}\" -f /tmp/mod.ldif",
-    cwd     => '/var/simp/environments/simp/FakeCA',
+    cwd     => "/var/simp/environments/${env}/FakeCA",
     require => [File['/tmp/mod.ldif'],Exec['packer_addto_ldap']]
   }
 

--- a/puppet/modules/simpsetup/manifests/site.pp
+++ b/puppet/modules/simpsetup/manifests/site.pp
@@ -6,9 +6,10 @@
 #  @param  $sitedir   The directory where the site manifests are.
 #
 class simpsetup::site (
-  String $sitedir  = '/etc/puppetlabs/code/environments/simp/modules/site/manifests'
+  String $env = $simpsetup::environment
 ){
 
+  $sitedir  = "/etc/puppetlabs/code/environments/${env}/modules/site/manifests"
   $file_perms = {
     'ensure'  => 'file',
     'owner'   => 'root',

--- a/puppet/modules/simpsetup/manifests/togen.pp
+++ b/puppet/modules/simpsetup/manifests/togen.pp
@@ -3,7 +3,9 @@
 #  It use the domain name from simpsetup also.
 #  It users server## and ws## for the names of the systems.
 #
-class simpsetup::togen {
+class simpsetup::togen (
+  String $env = $simpsetup::environment
+){
 
 $togen_template = @(END)
 <% $simpsetup::servers.each |$number| { %>
@@ -14,7 +16,7 @@ ws<%= $number %>.<%= $simpsetup::domain %>
 <% } %>
 END
 
-  file {  '/var/simp/environments/simp/FakeCA/togen':
+  file {  "/var/simp/environments/${env}/FakeCA/togen":
     owner   => 'root',
     group   => 'root',
     mode    => '0640',
@@ -22,9 +24,9 @@ END
   }
 
   exec { 'generate certs from togen':
-    command => '/var/simp/environments/simp/FakeCA/gencerts_nopass.sh',
-    cwd     => '/var/simp/environments/simp/FakeCA',
-    creates => "/var/simp/environments/simp/site_files/pki_files/files/keydist/ws33.${simpsetup::domain}",
-    require => File['/var/simp/environments/simp/FakeCA/togen']
+    command => "/var/simp/environments/${env}/FakeCA/gencerts_nopass.sh",
+    cwd     => "/var/simp/environments/${env}/FakeCA",
+    creates => "/var/simp/environments/${env}/site_files/pki_files/files/keydist/ws33.${simpsetup::domain}",
+    require => File["/var/simp/environments/${env}/FakeCA/togen"]
   }
 }

--- a/scripts/config/hiera_update.rb
+++ b/scripts/config/hiera_update.rb
@@ -3,7 +3,7 @@ require 'yaml'
 require 'fileutils'
 require 'socket'
 
-environment = 'production'
+environment = ENV['SIMP_PACKER_environment'] || 'production'
 hieradir = "/etc/puppetlabs/code/environments/#{environment}/data"
 simp_version = File.read('/etc/simp/simp.version').strip
 simp_version.gsub!(%r{\A(\d+(?:(?:\.\d+)?\.\d+)?).*}, '\1')

--- a/scripts/config/hiera_update.rb
+++ b/scripts/config/hiera_update.rb
@@ -3,11 +3,12 @@ require 'yaml'
 require 'fileutils'
 require 'socket'
 
-hieradir = '/etc/puppetlabs/code/environments/simp/data'
+environment = 'production'
+hieradir = "/etc/puppetlabs/code/environments/#{environment}/data"
 simp_version = File.read('/etc/simp/simp.version').strip
 simp_version.gsub!(%r{\A(\d+(?:(?:\.\d+)?\.\d+)?).*}, '\1')
 if Gem::Version.new(simp_version) < Gem::Version.new('6.3.0')
-  hieradir = '/etc/puppetlabs/code/environments/simp/hieradata'
+  hieradir = "/etc/puppetlabs/code/environments/#{environment}/hieradata"
 end
 
 time = Time.new

--- a/scripts/config/sitepp_edit.rb
+++ b/scripts/config/sitepp_edit.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
 require 'fileutils'
-environment='production'
+environment=ENV['SIMP_PACKER_environment'] || 'production'
 sitepp_file = "/etc/puppetlabs/code/environments/#{environment}/manifests/site.pp"
 backup_sitepp_file = "/etc/puppetlabs/code/environments/#{environment}/manifests/site.pp.packer.backup"
 

--- a/scripts/config/sitepp_edit.rb
+++ b/scripts/config/sitepp_edit.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
 require 'fileutils'
-environment=ENV['SIMP_PACKER_environment'] || 'production'
+environment = ENV['SIMP_PACKER_environment'] || 'production'
 sitepp_file = "/etc/puppetlabs/code/environments/#{environment}/manifests/site.pp"
 backup_sitepp_file = "/etc/puppetlabs/code/environments/#{environment}/manifests/site.pp.packer.backup"
 

--- a/scripts/config/sitepp_edit.rb
+++ b/scripts/config/sitepp_edit.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 #
 require 'fileutils'
-
-sitepp_file = '/etc/puppetlabs/code/environments/simp/manifests/site.pp'
-backup_sitepp_file = '/etc/puppetlabs/code/environments/simp/manifests/site.pp.packer.backup'
+environment='production'
+sitepp_file = "/etc/puppetlabs/code/environments/#{environment}/manifests/site.pp"
+backup_sitepp_file = "/etc/puppetlabs/code/environments/#{environment}/manifests/site.pp.packer.backup"
 
 if File.file?(backup_sitepp_file)
   puts "site.pp backup was found: #{backup_sitepp_file}.  This script will not run again."

--- a/scripts/puppet-usersetup.sh
+++ b/scripts/puppet-usersetup.sh
@@ -4,11 +4,10 @@
 #  incase it is Puppet 4.0
 export PATH="${PATH}:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin"
 packerdir="/var/local/simp"
-codedir=$(puppet config print environmentpath)
-pupenvdir=$(puppet config print environmentpath)
-pupenv=$(puppet config print environment)
-puppetmodpath="${codedir}/${pupenv}/modules"
-hieradata_dir="${pupenvdir}/${pupenv}/data"
+pupenvdir=$(puppet config print environmentpath 2> /dev/null)
+env=$(puppet config print environment 2> /dev/null)
+puppetmodpath="${pupenvdir}/${env}/modules"
+hieradata_dir="${pupenvdir}/${env}/data"
 
 simp_version="$(cat /etc/simp/simp.version)"
 semver=( ${simp_version//./ } )
@@ -17,7 +16,7 @@ minor="${semver[1]}"
 
 # Use old hieradata path when SIMP < 6.3.0
 if [[ ( "$major" -eq 6  &&  "$minor" -lt 3 ) || "$major" -le 5 ]]; then
-  hieradata_dir="$pupenvdir/simp/hieradata"
+  hieradata_dir="$pupenvdir/${env}/hieradata"
   sed -i -e 's@/data$@/hieradata@g' /root/.bashrc-extras
 fi
 
@@ -26,7 +25,7 @@ echo "The hiera data directory is: $hieradata_dir"
 
 # Install site module
 cp -R "${packerdir}/puppet/modules/site" "${puppetmodpath}/"
-chmod -R g+rx "${puppetmodpath}/site"
+chmod -R g+rX "${puppetmodpath}/site"
 chown -R root:puppet "${puppetmodpath}/site"
 
 # Include the vagrant manifest in  default along with
@@ -46,4 +45,4 @@ EOF
 chown root:puppet "${hieradata_dir}/default.yaml"
 chmod g+rX "${hieradata_dir}/default.yaml"
 
-puppet apply -e "include site::vagrant" --environment=production
+puppet apply -e "include site::vagrant" --environment=$env

--- a/scripts/puppet-usersetup.sh
+++ b/scripts/puppet-usersetup.sh
@@ -8,7 +8,7 @@ codedir=$(puppet config print environmentpath)
 pupenvdir=$(puppet config print environmentpath)
 pupenv=$(puppet config print environment)
 puppetmodpath="${codedir}/${pupenv}/modules"
-hieradata_dir="${pupenvdir}/simp/data"
+hieradata_dir="${pupenvdir}/${pupenv}/data"
 
 simp_version="$(cat /etc/simp/simp.version)"
 semver=( ${simp_version//./ } )
@@ -46,4 +46,4 @@ EOF
 chown root:puppet "${hieradata_dir}/default.yaml"
 chmod g+rX "${hieradata_dir}/default.yaml"
 
-puppet apply -e "include site::vagrant" --environment=simp
+puppet apply -e "include site::vagrant" --environment=production

--- a/scripts/tests/check_settings.sh
+++ b/scripts/tests/check_settings.sh
@@ -9,6 +9,8 @@ set -e
 
 ERR_NO_RUBY_EXE=71
 
+pupenv='production'
+
 for pth in /opt/puppetlabs/puppet/bin /opt/puppetlabs/bin; do
   if [ -z "$RUBY" ] && [ -x "$pth/ruby" ]; then
     export PATH="$pth:${PATH}"
@@ -19,7 +21,7 @@ done
 
 packerdir=${VAR_LOCAL_SIMP_DIR:-"/var/local/simp"}
 pupenvdir="$(puppet config print environmentpath 2> /dev/null)"
-hieradata_dir="${pupenvdir}/simp/data"
+hieradata_dir="${pupenvdir}/${pupenv}/data"
 
 simp_version="$(cat "${SIMP_VERSION_FILE:-/etc/simp/simp.version}")"
 semver=( ${simp_version//./ } )

--- a/scripts/tests/check_settings.sh
+++ b/scripts/tests/check_settings.sh
@@ -9,8 +9,6 @@ set -e
 
 ERR_NO_RUBY_EXE=71
 
-pupenv='production'
-
 for pth in /opt/puppetlabs/puppet/bin /opt/puppetlabs/bin; do
   if [ -z "$RUBY" ] && [ -x "$pth/ruby" ]; then
     export PATH="$pth:${PATH}"
@@ -19,6 +17,7 @@ for pth in /opt/puppetlabs/puppet/bin /opt/puppetlabs/bin; do
 done
 [ -z "$RUBY" ]&& { echo "ERROR: could not find a ruby executable"; exit "${ERR_NO_RUBY_EXE}"; }
 
+pupenv=$(puppet config print environment 2> /dev/null)
 packerdir=${VAR_LOCAL_SIMP_DIR:-"/var/local/simp"}
 pupenvdir="$(puppet config print environmentpath 2> /dev/null)"
 hieradata_dir="${pupenvdir}/${pupenv}/data"
@@ -34,4 +33,4 @@ if [[ ( "$major" -eq 6  &&  "$minor" -lt 3 ) || "$major" -le 5 ]]; then
 fi
 simp_default="${hieradata_dir}/simp_config_settings.yaml"
 
-ruby "${packerdir}/scripts/tests/check_settings.rb" "${packerdir}/files/simp_conf.yaml" "${simp_default}"
+SIMP_PACKER_environment=$pupenv ruby "${packerdir}/scripts/tests/check_settings.rb" "${packerdir}/files/simp_conf.yaml" "${simp_default}"

--- a/templates/simp.json.template
+++ b/templates/simp.json.template
@@ -160,7 +160,7 @@
       "destination": "/var/local/simp/files"
     },
     {
-      "destination": "/var/local/simp",
+      "destination": "/var/local/simp/",
       "source": "./puppet",
       "type": "file"
     },
@@ -169,6 +169,12 @@
     //
     // These should run without sudo (the environment vars do not work).
     // ------------------------------------------------------------------------
+    // Grant all uploaded scripts premission to execute on the server
+    {
+      "type": "shell",
+      "remote_path": "/var/local/simp/scripts/inline-find-chmod-x--var-local-simp-scripts.sh",
+      "inline": [ "sudo find /var/local/simp/scripts -type f -name '*.sh' -print -exec chmod +x {} \\;" ]
+    },
     {
       "type": "shell",
       "remote_path": "/var/local/simp/scripts/tests/check_settings_at_boot.sh",
@@ -216,7 +222,6 @@
          "fi"
       ]
     },
-
     // FIX ME Set up the initial Environment.  This will eventually be a simp env command
     //  The script also installs simp-vendored-r10k.
     {
@@ -224,7 +229,10 @@
       "remote_path": "/var/local/simp/scripts/inline-newenv.sh",
       "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo -i '{{.Path}}'",
       "inline" : [
-        "/usr/local/bin/simpenv -n simp"
+        "if [[ -d /etc/puppetlabs/code/environments/production ]]; then",
+          "mv /etc/puppetlabs/code/environments/production /etc/puppetlabs/code/environments/orig_production",
+        "fi",
+        "/usr/local/sbin/simpenv -n production"
         ]
     },
     //  Create the puppet files and install the puppetmodules
@@ -232,12 +240,19 @@
       "remote_path": "/var/local/simp/inline-simp-puppet-file.sh",
       "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo -i '{{.Path}}'",
       "inline" : [
-        "cd /etc/puppetlabs/code/environments/simp",
+        "cd /etc/puppetlabs/code/environments/production",
         "umask 0027",
-        "sg puppet -c '/usr/share/simp/bin/r10k puppetfile install --puppetfile /etc/puppetlabs/code/environments/simp/Puppetfile --moduledir /etc/puppetlabs/code/environments/simp/modules'"
+        "sg puppet -c '/usr/share/simp/bin/r10k puppetfile install --puppetfile /etc/puppetlabs/code/environments/production/Puppetfile --moduledir /etc/puppetlabs/code/environments/production/modules'"
       ]
     },
-
+    // Make sure That packer can still access the system by setting up the
+    // site::vagrant manifest to be called when puppet is run.
+    {
+     "type": "shell",
+      "remote_path": "/var/local/simp/scripts/puppet-usersetup.sh",
+      "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo -i '{{.Path}}'",
+      "script" : "scripts/puppet-usersetup.sh"
+    },
     // Now we run simp using the simp conf yaml file specified in the shell.
     // It should complete successfully.
     {
@@ -250,7 +265,7 @@
          "echo 'umask:'",
          "umask",
          "echo 'Running simp config...'",
-         "simp config -a {{user `simp_conf_file`}}"
+         "simp config -a {{user `simp_conf_file`}} --force-config"
       ]
     },
     // Disable NetworkManager (may prevent a problem with beaker)
@@ -260,7 +275,6 @@
       "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo bash '{{.Path}}'",
       "inline" : [ "/opt/puppetlabs/bin/puppet resource service NetworkManager ensure=stopped enable=false" ]
     },
-
     // Now run bootstrap.
     //
     // This script also configures a puppet manifest `site::vagrant` that
@@ -339,13 +353,6 @@
       "extra_arguments": "--test",
       "staging_dir": "/var/local/simp/scripts",
       "puppet_bin_dir": "/opt/puppetlabs/bin"
-    },
-
-    // Grant all uploaded scripts premission to execute on the server
-    {
-      "type": "shell",
-      "remote_path": "/var/local/simp/scripts/inline-find-chmod-x--var-local-simp-scripts.sh",
-      "inline": [ "sudo find /var/local/simp/scripts -type f -name '*.sh' -print -exec chmod +x {} \\;" ]
     },
 
     // TEST: Check settings after bootstrap.

--- a/templates/simp.json.template
+++ b/templates/simp.json.template
@@ -181,7 +181,8 @@
       "execute_command": "chmod +x {{.Path}}; {{.Vars}} sh '{{.Path}}'",
       "environment_vars" : [
         "SIMP_PACKER_fips={{user `fips`}}",
-        "SIMP_PACKER_disk_encrypt={{user `disk_encrypt`}}"
+        "SIMP_PACKER_disk_encrypt={{user `disk_encrypt`}}",
+        "SIMP_PACKER_environment={{user `simpenvironment`}}"
       ],
       "script" : "scripts/tests/check_settings_at_boot.sh"
     },
@@ -229,10 +230,11 @@
       "remote_path": "/var/local/simp/scripts/inline-newenv.sh",
       "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo -i '{{.Path}}'",
       "inline" : [
-        "if [[ -d /etc/puppetlabs/code/environments/production ]]; then",
-          "mv /etc/puppetlabs/code/environments/production /etc/puppetlabs/code/environments/orig_production",
+        "env=\"{{user `simpenvironment`}}\"",
+        "if [[ -d /etc/puppetlabs/code/environments/$env ]]; then",
+          "mv /etc/puppetlabs/code/environments/$env /etc/puppetlabs/code/environments/orig_$env",
         "fi",
-        "/usr/local/sbin/simpenv -n production"
+        "/usr/local/sbin/simpenv -n $env"
         ]
     },
     //  Create the puppet files and install the puppetmodules
@@ -240,15 +242,19 @@
       "remote_path": "/var/local/simp/inline-simp-puppet-file.sh",
       "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo -i '{{.Path}}'",
       "inline" : [
-        "cd /etc/puppetlabs/code/environments/production",
+        "env=\"{{user `simpenvironment`}}\"",
+        "cd /etc/puppetlabs/code/environments/$env",
         "umask 0027",
-        "sg puppet -c '/usr/share/simp/bin/r10k puppetfile install --puppetfile /etc/puppetlabs/code/environments/production/Puppetfile --moduledir /etc/puppetlabs/code/environments/production/modules'"
+        "sg puppet -c \"/usr/share/simp/bin/r10k puppetfile install --puppetfile /etc/puppetlabs/code/environments/$env/Puppetfile --moduledir /etc/puppetlabs/code/environments/$env/modules\""
       ]
     },
     // Make sure That packer can still access the system by setting up the
     // site::vagrant manifest to be called when puppet is run.
     {
-     "type": "shell",
+      "type": "shell",
+      "environment_vars" : [
+        "SIMP_PACKER_environment={{user `simpenvironment`}}"
+      ],
       "remote_path": "/var/local/simp/scripts/puppet-usersetup.sh",
       "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo -i '{{.Path}}'",
       "script" : "scripts/puppet-usersetup.sh"
@@ -284,7 +290,7 @@
     // TODO: Move `site::vagrant` out of the bash script heredoc and into its
     //       own file.
     {
-     "type": "shell",
+      "type": "shell",
       "remote_path": "/var/local/simp/scripts/simp-bootstrap.sh",
       "execute_command": "sudo chmod +x {{.Path}}; {{.Vars}} sudo -i '{{.Path}}'",
       "script" : "scripts/simp-bootstrap.sh"
@@ -380,11 +386,17 @@
     },
     {
       "type": "shell",
+      "environment_vars" : [
+        "SIMP_PACKER_environment={{user `simpenvironment`}}"
+      ],
       "remote_path": "/var/local/simp/scripts/inline-run-sitepp_edit-rb.sh",
       "inline": ["sudo {{user `ruby_path`}} /var/local/simp/scripts/config/sitepp_edit.rb"]
     },
     {
       "type": "shell",
+      "environment_vars" : [
+        "SIMP_PACKER_environment={{user `simpenvironment`}}"
+      ],
       "remote_path": "/var/local/simp/scripts/inline-run-hiera_update-rb.sh",
       "inline": ["sudo {{user `ruby_path`}} /var/local/simp/scripts/config/hiera_update.rb"]
     },


### PR DESCRIPTION
- update to work with    
    simp-environment-skeleton >= 7.0.0
    simp-rsync-skeleton >= 7.0.0
    simp-adapter >= 1.0.0
    simp-cli >= 5.0.0
    simp-utils >= 6.2.0
- not backwards compatable
- added packer user variable to set environment directory.
     