### PR TITLE
(SIMP-MAINT) Prep release of version used in SIMP 6.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
-Fri Jul 05 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
+Fri Jul 05 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.4.0
 * Update to use SIMP 6.4.0 RC1 which has new changes to simp-cli.
   
-Wed May 08 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
+Wed May 08 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.4.0
 * Update to use simp-cli 6.4 alpha (version 5.0.0).  This puts things in production environment.
   Added packer user variable simpenviroment so the directory where files are
   copied to can be changed.  How ever the scripts
@@ -15,11 +15,11 @@ Wed May 08 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
     simp-cli >= 5.0.0
     simp-utils >= 6.2.0
 
-Mon Apr 29 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
+Mon Apr 29 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.4.0
 * change simp.json file to use simpenv script in simp-utils
 * removed linked file in site module.  Packer can't handle linked files
 
-Thu Apr 18 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
+Thu Apr 18 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.4.0
 * Updated to work with new r10k iso install process.  It will no longer work
   with older builds.  You need to checkout version 2.3.0 to  build an older
   version.
@@ -37,7 +37,7 @@ Thu Apr 18 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - UNRELEASED
 * removed support for puppet 4.10 and ruby 2.1.9.
 
 
-Mon Apr 01 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - UNRELEASED
+Mon Apr 01 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.4.0
 
 This patch refactors the `simp_packer_test.sh` and `simp_config.rb` scripts
 into testable Ruby classes, and adds a few example unit tests.


### PR DESCRIPTION
Before updating for SIMP 6.5.0, we need to release this version,
which was used to test SIMP 6.4.0.