### PR TITLE
(SIMP-MAINT) simp-packer updates for Puppet 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples explicitly target SIMP 6.5.0 (instead of "6.X")
 - 'site' module dependency version ranges now accomodate SIMP 6.5.0
 - Converted CHANGELOG into format documented at https://keepachangelog.com/
+- Refined regex used to check for puppetserver and puppetdb service status to
+  support both Puppet 5 and Puppet 6.
 
 ### Removed
 - Dropped support for all SIMP releases older than 6.5.0

--- a/scripts/tests/check_settings.rb
+++ b/scripts/tests/check_settings.rb
@@ -96,7 +96,7 @@ class CheckSettings
   #   puppet resource service <service name>
   def check_service_status(service, expected_status = 'running')
     result = %x(puppet resource service #{service})
-    match = result.match(%r{ensure => '(stopped|running)',})
+    match = result.match(%r{ensure\s+=> '(stopped|running)',})
     if match
       if match[1] == expected_status
         puts "Service '#{service}' status matches expected value '#{expected_status}'."
@@ -112,7 +112,8 @@ class CheckSettings
       #    enable => 'false'
       #   }
       # So we must really be broken, if the puppet CLI doesn't work!
-      err_msg = "Unable to determine #{service} status using 'puppet resource service'."
+      err_msg = "Unable to determine #{service} status using 'puppet resource service':"
+      err_msg += "\n#{result}"
       raise SettingsError, err_msg
     end
   end


### PR DESCRIPTION
Fixed a regex used when checking the status of the puppetserver
and puppetdb services. Also, printed out the status result to
aid in debug, should this failure happen again.