### PR TITLE
(SIMP-MAINT) Remove temporary hacks for SIMP 6.1

### DIFF
--- a/scripts/simp-bootstrap.sh
+++ b/scripts/simp-bootstrap.sh
@@ -2,21 +2,6 @@
 
 ORIGINAL_UMASK="$(umask)"
 
-# TODO: this hack is not a permanent solution.
-# shellcheck disable=SC2039
-if [[ "$(cat /etc/simp/simp.version)" =~ ^6\.1\.0- ]]; then
- echo "====================================================="
- echo "====================================================="
- echo "================   SIMP 6.1.0  ======================"
- echo "====================================================="
- echo "====================================================="
- echo "======= SIMP-4482 hack: setting umask to 0022 ======="
- echo "====================================================="
- echo "====================================================="
- echo "====================================================="
- umask 0022
-fi
-
 # run bootstrap
 echo "**********************"
 echo "Running Simp Bootstrap"
@@ -39,20 +24,3 @@ echo "**********************"
 echo "Configuring simp user"
 echo "**********************"
 /var/local/simp/scripts/puppet-usersetup.sh
-
-# TODO: this hack is not a permanent solution.
-# shellcheck disable=SC2039
-if [[ "$(cat /etc/simp/simp.version)" =~ ^6\.1\.0- ]]; then
- chmod go=u-w /etc/puppetlabs/puppet/puppetdb.conf
-
- echo "====================================================="
- echo "====================================================="
- echo "================   SIMP 6.1.0  ======================"
- echo "====================================================="
- echo "====================================================="
- echo "==== SIMP-4482 hack: reverting to original umask ===="
- echo "====================================================="
- echo "====================================================="
- echo "====================================================="
- umask "$ORIGINAL_UMASK"
-fi


### PR DESCRIPTION
This patch removes the SIMP 6.1.0-specific hacks from
[SIMP-4482]/[SIMP-4417].

The hacks are no longer relevant now that simp-packer has dropped
support for SIMP < 6.5.0


[SIMP-4482]: https://simp-project.atlassian.net/browse/SIMP-4482
[SIMP-4417]: https://simp-project.atlassian.net/browse/SIMP-4417