### PR TITLE
(SIMP-MAINT) Add local site module to Puppetfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added
@@ -33,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Enabled FIPS mode in the `fips7` sample's `simp_conf.yaml`
+- Local site module is now appended to the environment's
+  Puppetfile so that the module persists when r10k is used to
+  deploy the modules in upgrade tests.
+- Removed extraneous call to puppet-usersetup.sh from simp-bootstrap.sh.
+  This script was called already called between `simp config` and
+  `simp bootstrap`.
 
 ## [2.4.0] - 2019-07-05
 

--- a/scripts/puppet-usersetup.sh
+++ b/scripts/puppet-usersetup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 #  Because this script is used before the reboot the path is not
 #  set for simp user so I add this to the end
 #  incase it is Puppet 4.0
@@ -39,4 +40,6 @@ EOF
 chown root:puppet "${hieradata_dir}/default.yaml"
 chmod g+rX "${hieradata_dir}/default.yaml"
 
-#puppet apply -e "include site::vagrant" --environment=$env
+# Need to add to Puppetfile in the environment as a local module
+# or it will be removed when upgrading and r10K is called.
+echo "mod 'site', :local => true" >> "${pupenvdir}/${env}/Puppetfile"

--- a/scripts/simp-bootstrap.sh
+++ b/scripts/simp-bootstrap.sh
@@ -16,11 +16,3 @@ echo "**********************"
 
 cat /root/.simp/simp_bootstrap.log*
 echo "****** End of Bootstrap Log ****************"
-
-#  Have to execute this or the next provisioning scripts
-#  won't be able to ssh and sudo because simp will
-#  have turned off the permissions.
-echo "**********************"
-echo "Configuring simp user"
-echo "**********************"
-/var/local/simp/scripts/puppet-usersetup.sh


### PR DESCRIPTION
- Fixed:
  - Local site module is now appended to the environment's
    Puppetfile so that the module persists when r10k is used to
    deploy the modules in upgrade tests.
  - Removed extraneous call to puppet-usersetup.sh from simp-bootstrap.sh.
    This script was called already called between `simp config` and
    `simp bootstrap`.