### PR TITLE
(SIMP-8818) Run `packer fix` just before building

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,7 @@ variables:
 .lint_tests: &lint_tests
   stage: 'validation'
   tags: ['docker']
+  <<: *pup_6_18
   <<: *setup_bundler_env
 
 .unit_tests: &unit_tests
@@ -97,14 +98,15 @@ rubocop:
 
 shellcheck:
   stage: 'validation'
+  <<: *lint_tests
   tags: ['shellcheck']
   script:
     - 'bundle exec rake test:shellcheck'
 
 packer:
   stage: 'validation'
+  <<: *lint_tests
   tags: ['packer']
-  <<: *setup_bundler_env
   script:
     - 'packer --version'
     - 'bundle exec rake packer:validate'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,122 @@
+# The testing matrix considers ruby/puppet versions supported by SIMP:
+# --------------------------------------------------------------------
+# Release       Puppet   Ruby    EOL
+# SIMP 6.4      5.5      2.4.10  TBD
+# SIMP 6.5      6.18     2.4.10  TBD
+---
+stages:
+  - 'validation'
+  - 'acceptance'
+  - 'compliance'
+  - 'deployment'
+
+image: 'ruby:2.5'
+
+variables:
+  PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
+  BUNDLER_VERSION:   '1.17.1'
+
+  # Force dependencies into a path the gitlab-runner user can write to.
+  # (This avoids some failures on Runners with misconfigured ruby environments.)
+  GEM_HOME:          .vendor/gem_install
+  BUNDLE_CACHE_PATH: .vendor/bundle
+  BUNDLE_PATH:       .vendor/bundle
+  BUNDLE_BIN:        .vendor/gem_install/bin
+  BUNDLE_NO_PRUNE:   'true'
+
+
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
+.setup_bundler_env: &setup_bundler_env
+  cache:
+    untracked: true
+    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
+    paths:
+      - '.vendor'
+  before_script:
+    - 'ruby -e "puts %(Environment Variables:\n  * #{ENV.keys.grep(/PUPPET|SIMP|BEAKER|MATRIX/).map{|v| %(#{v} = #{ENV[v]})}.join(%(\n  * ))})"'
+    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-1.16.0}")'
+    - 'declare GEM_INSTALL_CMD=(gem install --no-document)'
+    - 'declare BUNDLER_INSTALL_CMD=(bundle install --no-binstubs --jobs $(nproc) "${FLAGS[@]}")'
+    - 'mkdir -p ${GEM_HOME} ${BUNDLER_BIN}'
+    - 'gem list -ie "${GEM_BUNDLER_VER[@]}" --silent bundler || "${GEM_INSTALL_CMD[@]}" --local "${GEM_BUNDLER_VER[@]}" bundler || "${GEM_INSTALL_CMD[@]}" "${GEM_BUNDLER_VER[@]}" bundler'
+    - 'rm -rf pkg/ || :'
+    - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || { echo "PIPELINE: Bundler could not install everything (see log output above)" && exit 99 ; }'
+
+# To avoid running a prohibitive number of tests every commit,
+# don't set this env var in your gitlab instance
+.only_with_SIMP_FULL_MATRIX: &only_with_SIMP_FULL_MATRIX
+  only:
+    variables:
+      - $SIMP_FULL_MATRIX == "yes"
+
+# Puppet Versions
+#-----------------------------------------------------------------------
+
+.pup_5_5_20: &pup_5_5_20
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '5.5.20'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_6_18: &pup_6_18
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '~> 6.18.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
+
+# Testing Environments
+#-----------------------------------------------------------------------
+
+.lint_tests: &lint_tests
+  stage: 'validation'
+  tags: ['docker']
+  <<: *setup_bundler_env
+
+.unit_tests: &unit_tests
+  stage: 'validation'
+  tags: ['docker']
+  <<: *setup_bundler_env
+  script:
+    - 'bundle exec rake spec'
+
+
+# Pipeline / testing matrix
+#=======================================================================
+
+rubocop:
+  <<: *lint_tests
+  script:
+    - 'bundle exec rake test:rubocop'
+
+shellcheck:
+  stage: 'validation'
+  tags: ['shellcheck']
+  script:
+    - 'bundle exec rake test:shellcheck'
+
+packer:
+  stage: 'validation'
+  tags: ['packer']
+  <<: *setup_bundler_env
+  script:
+    - 'packer --version'
+    - 'bundle exec rake packer:validate'
+
+# Spec tests
+#=======================================================================
+pup5.5.20-unit:
+  <<: *pup_5_5_20
+  <<: *unit_tests
+
+
+pup6.18-unit:
+  <<: *pup_6_18
+  <<: *unit_tests
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,61 +65,67 @@ before_install:
   - gem update --system --no-document
 
 jobs:
-  allow_failures:
-    - name: 'Latest Puppet 5.x (allowed to fail)'
-    - name: 'Latest Puppet 6.x (allowed to fail)'
+  ### allow_failures:
+  ###   - name: 'Latest Puppet 5.x (allowed to fail)'
+  ###   - name: 'Latest Puppet 6.x (allowed to fail)'
 
   include:
-    - stage:  validation
-      name:   Rubocop
-      script: bundle exec rake test:rubocop
-
-    - stage:  validation
-      name:   Shellcheck
-      script: bundle exec rake test:shellcheck
-
-    - stage:  validation
-      name:   'Validate simp.json (packer 1.4.0)'
-      env:
-        - 'ver=1.4.0'
-        - 'PATH="$PWD/packer-bin/${ver}:${PATH}"'
-      before_script:
-        - 'test -f "packer-bin/${ver}/packer" || { wget -c "https://releases.hashicorp.com/packer/${ver}/packer_${ver}_linux_amd64.zip" -O packer.zip && mkdir -p "packer-bin/${ver}" && cd "packer-bin/${ver}" && unzip ../../packer.zip ; cd - ; }'
-        - 'packer --version'
-      script: bundle exec rake packer:validate
-
-    - stage: 'Spec tests'
-      rvm:    2.4.9
-      name:  'Ruby unit tests (Ruby 2.4.9)'
-      script: bundle exec rake spec
-
-    - stage:  'Spec tests'
-      name:   'Puppet 5.5 (SIMP 6.3+)'
-      rvm:    2.4.9
-      env:
-        - 'PUPPET_VERSION="~> 5.5.6"'
-      script: bundle exec rake test:puppet
-
-    - stage:  'Spec tests'
-      name:   'Latest Puppet 5.x (allowed to fail)'
-      rvm:    2.4.4
-      env:
-        - 'PUPPET_VERSION="~> 5.0"'
-      script: bundle exec rake test:puppet
-
-    - stage:  'Spec tests'
-      name: 'Puppet 6.18 (PE 2019.2)'
-      rvm: 2.5.7
-      env: PUPPET_VERSION="~> 6.18.0"
-      script:
-        - bundle exec rake spec
-
-    - stage:  'Spec tests'
-      name:   'Latest Puppet 6.x (allowed to fail)'
-      rvm:    2.5.7
-      env:
-        - 'PUPPET_VERSION="~> 6.0"'
-      script: bundle exec rake test:puppet
+    ###  Testing on Travis CI is indefinitely disabled
+    ###
+    ###  See:
+    ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    ###    * https://simp-project.atlassian.net/browse/SIMP-8703
+    ###
+    ###    - stage:  validation
+    ###      name:   Rubocop
+    ###      script: bundle exec rake test:rubocop
+    ###
+    ###    - stage:  validation
+    ###      name:   Shellcheck
+    ###      script: bundle exec rake test:shellcheck
+    ###
+    ###    - stage:  validation
+    ###      name:   'Validate simp.json (packer 1.4.0)'
+    ###      env:
+    ###        - 'ver=1.4.0'
+    ###        - 'PATH="$PWD/packer-bin/${ver}:${PATH}"'
+    ###      before_script:
+    ###        - 'test -f "packer-bin/${ver}/packer" || { wget -c "https://releases.hashicorp.com/packer/${ver}/packer_${ver}_linux_amd64.zip" -O packer.zip && mkdir -p "packer-bin/${ver}" && cd "packer-bin/${ver}" && unzip ../../packer.zip ; cd - ; }'
+    ###        - 'packer --version'
+    ###      script: bundle exec rake packer:validate
+    ###
+    ###    - stage: 'Spec tests'
+    ###      rvm:    2.4.9
+    ###      name:  'Ruby unit tests (Ruby 2.4.9)'
+    ###      script: bundle exec rake spec
+    ###
+    ###    - stage:  'Spec tests'
+    ###      name:   'Puppet 5.5 (SIMP 6.3+)'
+    ###      rvm:    2.4.9
+    ###      env:
+    ###        - 'PUPPET_VERSION="~> 5.5.6"'
+    ###      script: bundle exec rake test:puppet
+    ###
+    ###    - stage:  'Spec tests'
+    ###      name:   'Latest Puppet 5.x (allowed to fail)'
+    ###      rvm:    2.4.4
+    ###      env:
+    ###        - 'PUPPET_VERSION="~> 5.0"'
+    ###      script: bundle exec rake test:puppet
+    ###
+    ###    - stage:  'Spec tests'
+    ###      name: 'Puppet 6.18 (PE 2019.2)'
+    ###      rvm: 2.5.7
+    ###      env: PUPPET_VERSION="~> 6.18.0"
+    ###      script:
+    ###        - bundle exec rake spec
+    ###
+    ###    - stage:  'Spec tests'
+    ###      name:   'Latest Puppet 6.x (allowed to fail)'
+    ###      rvm:    2.5.7
+    ###      env:
+    ###        - 'PUPPET_VERSION="~> 6.0"'
+    ###      script: bundle exec rake test:puppet
 
     - stage: deploy
       script:

--- a/lib/simp/packer/build/runner.rb
+++ b/lib/simp/packer/build/runner.rb
@@ -121,7 +121,7 @@ module Simp
             end
 
             cmd = <<-CMD.gsub(%r{ {10}}, '')
-              set -e; -o pipefail;
+              set -e; set -o pipefail;
               #{opts[:tmp_dir] ? "TMP_DIR=#{opts[:tmp_dir]} " : ''}PACKER_LOG="#{ENV['PACKER_LOG'] || 1}" \
                 PACKER_LOG_PATH="#{opts[:plog_file]}" \
                 packer build -var-file="#{working_dir}/vars.json" #{opts[:extra_packer_args]} "#{working_dir}/simp.json" \

--- a/lib/simp/packer/build/runner.rb
+++ b/lib/simp/packer/build/runner.rb
@@ -107,6 +107,15 @@ module Simp
 
           Dir.chdir working_dir do |_dir|
             puts "Logs will be written to #{opts[:log_file]}" if @verbose
+
+            fix_cmd = <<~FIX_CMD
+              set -e; set -o pipefail;
+               #{opts[:tmp_dir] ? "TMP_DIR=#{opts[:tmp_dir]} " : ''}PACKER_LOG="#{ENV['PACKER_LOG'] || 1}" \
+                 PACKER_LOG_PATH="#{opts[:plog_file]}.fix.log" \
+                    packer fix "#{working_dir}/simp.json" > "#{working_dir}/simp.json.fixed"; mv "#{working_dir}/simp.json" "#{working_dir}/simp.json.old"; mv "#{working_dir}/simp.json.fixed" "#{working_dir}/simp.json"
+            FIX_CMD
+            sh fix_cmd
+
             cmd = <<-CMD.gsub(%r{ {10}}, '')
               set -e; set -o pipefail;
               #{opts[:tmp_dir] ? "TMP_DIR=#{opts[:tmp_dir]} " : ''}PACKER_LOG="#{ENV['PACKER_LOG'] || 1}" \

--- a/lib/simp/packer/build/runner.rb
+++ b/lib/simp/packer/build/runner.rb
@@ -114,10 +114,14 @@ module Simp
                  PACKER_LOG_PATH="#{opts[:plog_file]}.fix.log" \
                     packer fix "#{working_dir}/simp.json" > "#{working_dir}/simp.json.fixed"; mv "#{working_dir}/simp.json" "#{working_dir}/simp.json.old"; mv "#{working_dir}/simp.json.fixed" "#{working_dir}/simp.json"
             FIX_CMD
-            sh fix_cmd
+            if opts[:dry_run]
+              puts cmd fix_cmd if @verbose
+            else
+              sh fix_cmd
+            end
 
             cmd = <<-CMD.gsub(%r{ {10}}, '')
-              set -e; set -o pipefail;
+              set -e; -o pipefail;
               #{opts[:tmp_dir] ? "TMP_DIR=#{opts[:tmp_dir]} " : ''}PACKER_LOG="#{ENV['PACKER_LOG'] || 1}" \
                 PACKER_LOG_PATH="#{opts[:plog_file]}" \
                 packer build -var-file="#{working_dir}/vars.json" #{opts[:extra_packer_args]} "#{working_dir}/simp.json" \

--- a/spec/lib/simp/packer/build/runner_spec.rb
+++ b/spec/lib/simp/packer/build/runner_spec.rb
@@ -92,14 +92,15 @@ describe Simp::Packer::Build::Runner do
 
       context 'when unable to configure the network' do
         before(:each) do
-          allow(Kernel).to receive(:system).with(
+          allow_any_instance_of(Kernel).to receive(:system).with(
             'VBoxManage hostonlyif ipconfig vboxnet5 --ip 192.168.101.1 --netmask 255.255.255.0',
           ).and_return(false)
         end
 
         it 'fails with an error' do
-          expect { @obj.run(dry_run: true) }.to raise_error(RuntimeError,
-                                                            %r{Failure to configure.*VBoxManage hostonlyif ipconfig vboxnet5})
+          expect { @obj.run(dry_run: true) }.to raise_error(
+            RuntimeError, %r{Failure to configure.*VBoxManage hostonlyif ipconfig vboxnet5}
+          )
         end
       end
     end


### PR DESCRIPTION
This patch fixes an issue where simp-packer builds would fail when using
recent packer versions because of deprecated keys in the generated JSON
template file:

       Deprecated configuration key: 'iso_checksum_type'.
       Please call `packer fix`

This patch implements that suggestion by simply running `packer fix` to
modernize the generated JSON file immediately prior to `packer build`.

[SIMP-8818] #close
[SIMP-8805] #close #comment Disable Travis CI tests

[SIMP-8818]: https://simp-project.atlassian.net/browse/SIMP-8818

[SIMP-8805]: https://simp-project.atlassian.net/browse/SIMP-8805